### PR TITLE
memphis-doc-library-css-bugfix

### DIFF
--- a/wp-content/themes/ucusergroup/functions.php
+++ b/wp-content/themes/ucusergroup/functions.php
@@ -916,3 +916,14 @@ function showExtraFields()
 
 	}
 }
+
+// Unregister the Bootstrap css file enqueued from the Memphis Document Library
+// as it clashes with the theme bootstrap because it is loaded too late.
+// This css file is manually added in ucusergroup/parts/shared/html-header.php
+// just before the theme bootstrap file
+function dequeue_memphis_doc_library_bootstrap() {
+	if ( is_plugin_active( 'memphis-documents-library/memphis-documents.php' ) ) {
+		wp_dequeue_style( 'bootstrap.min.css' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'dequeue_memphis_doc_library_bootstrap');

--- a/wp-content/themes/ucusergroup/parts/shared/html-header.php
+++ b/wp-content/themes/ucusergroup/parts/shared/html-header.php
@@ -13,6 +13,15 @@
 		<link rel="shortcut icon" href="<?php echo get_stylesheet_directory_uri(); ?>/img/favicon.ico"/>
 
 		<!-- STYLESHEETS -->
+		<?php if ( is_plugin_active( 'memphis-documents-library/memphis-documents.php' ) ) :
+			if(MDOCS_DEV) {
+				$bootstrap_css_file = 'bootstrap/bootstrap.css';
+			} else {
+				$bootstrap_css_file = 'bootstrap/bootstrap.min.css';
+			}
+		?>
+			<link href="<? echo MDOC_URL . $bootstrap_css_file; ?>" rel="stylesheet" media="all" />
+		<?php endif; ?>
 		<link href="<? echo get_template_directory_uri() ?>/css/bootstrap.css" rel="stylesheet" media="all" />
 		<link href="<? echo get_template_directory_uri() ?>/css/all.css" rel="stylesheet" media="all" />
 		<link href='http://fonts.googleapis.com/css?family=Lato:400,300,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Fix a CSS file incompatibility between the ucusergroup theme and the Memphis Documents Library plugin